### PR TITLE
Simplify inspection steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ go install github.com/Buzzvil/recovergoroutine
 recovergoroutine -recover="" ./...
 
 # -recover string
-#         Custom recover method name. Currently, it is difficult to determine
-#         if a CustomRecover function declared in another package is valid,
-#         so this option can be used to resolve it.
+#         Custom recovery method name. You can use this option
+#         when you want to call a method defined in a struct or
+#         use CustomRecover declared in an external package.
 ```
 
 Check out the test cases for validation [examples](./test/src/faildata/failcode.go).

--- a/test/src/custom/recover.go
+++ b/test/src/custom/recover.go
@@ -1,0 +1,1 @@
+package custom

--- a/test/src/faildata/failcode.go
+++ b/test/src/faildata/failcode.go
@@ -1,61 +1,62 @@
 package faildata
 
-func whenASTFuncLit() {
-	go func() {
-		defer func() {
-			// recover comment
-		}()
-	}()
-
-	go func() {
-		// recover variable
-		var recover = 1
-		foo(recover)
-	}()
-
-	func() {
-		// not checked
-	}()
-
-	go func() {
-		// not used defer
-		recover()
-	}()
-
-	go func() {
-		defer customRecover()
-	}()
-}
-
-func whenASTIndent() {
-	go runGoroutine()
-	go nestedFunc1()
-}
-
-func whenCallMethod() {
-	foo := &Foo{}
-	go foo.run()
-	go func() {
-		defer foo.Recover()
-	}()
-}
-
-func runGoroutine() {}
-
-func foo(_ int) {}
-
-func nestedFunc1() {
-	// must have recover in parent caller
-	recover()
-	nestedFunc2()
-}
-
-func nestedFunc2() {}
-
-func customRecover() {}
-
-type Foo struct{}
-
-func (a *Foo) run() {}
-
-func (a *Foo) Recover() {}
+//
+//func whenASTFuncLit() {
+//	go func() {
+//		defer func() {
+//			// recover comment
+//		}()
+//	}()
+//
+//	go func() {
+//		// recover variable
+//		var recover = 1
+//		foo(recover)
+//	}()
+//
+//	func() {
+//		// not checked
+//	}()
+//
+//	go func() {
+//		// not used defer
+//		recover()
+//	}()
+//
+//	go func() {
+//		defer customRecover()
+//	}()
+//}
+//
+//func whenASTIndent() {
+//	go runGoroutine()
+//	go nestedFunc1()
+//}
+//
+//func whenCallMethod() {
+//	foo := &Foo{}
+//	go foo.run()
+//	go func() {
+//		defer foo.Recover()
+//	}()
+//}
+//
+//func runGoroutine() {}
+//
+//func foo(_ int) {}
+//
+//func nestedFunc1() {
+//	// must have recover in parent caller
+//	recover()
+//	nestedFunc2()
+//}
+//
+//func nestedFunc2() {}
+//
+//func customRecover() {}
+//
+//type Foo struct{}
+//
+//func (a *Foo) run() {}
+//
+//func (a *Foo) Recover() {}

--- a/test/src/faildata/failcode.go
+++ b/test/src/faildata/failcode.go
@@ -1,62 +1,61 @@
 package faildata
 
-//
-//func whenASTFuncLit() {
-//	go func() {
-//		defer func() {
-//			// recover comment
-//		}()
-//	}()
-//
-//	go func() {
-//		// recover variable
-//		var recover = 1
-//		foo(recover)
-//	}()
-//
-//	func() {
-//		// not checked
-//	}()
-//
-//	go func() {
-//		// not used defer
-//		recover()
-//	}()
-//
-//	go func() {
-//		defer customRecover()
-//	}()
-//}
-//
-//func whenASTIndent() {
-//	go runGoroutine()
-//	go nestedFunc1()
-//}
-//
-//func whenCallMethod() {
-//	foo := &Foo{}
-//	go foo.run()
-//	go func() {
-//		defer foo.Recover()
-//	}()
-//}
-//
-//func runGoroutine() {}
-//
-//func foo(_ int) {}
-//
-//func nestedFunc1() {
-//	// must have recover in parent caller
-//	recover()
-//	nestedFunc2()
-//}
-//
-//func nestedFunc2() {}
-//
-//func customRecover() {}
-//
-//type Foo struct{}
-//
-//func (a *Foo) run() {}
-//
-//func (a *Foo) Recover() {}
+func whenASTFuncLit() {
+	go func() {
+		defer func() {
+			// recover comment
+		}()
+	}()
+
+	go func() {
+		// recover variable
+		var recover = 1
+		foo(recover)
+	}()
+
+	func() {
+		// not checked
+	}()
+
+	go func() {
+		// not used defer
+		recover()
+	}()
+
+	go func() {
+		defer customRecover()
+	}()
+}
+
+func whenASTIndent() {
+	go runGoroutine()
+	go nestedFunc1()
+}
+
+func whenCallMethod() {
+	foo := &Foo{}
+	go foo.run()
+	go func() {
+		defer foo.Recover()
+	}()
+}
+
+func runGoroutine() {}
+
+func foo(_ int) {}
+
+func nestedFunc1() {
+	// must have recover in parent caller
+	recover()
+	nestedFunc2()
+}
+
+func nestedFunc2() {}
+
+func customRecover() {}
+
+type Foo struct{}
+
+func (a *Foo) run() {}
+
+func (a *Foo) Recover() {}

--- a/test/src/succdata/succcode.go
+++ b/test/src/succdata/succcode.go
@@ -2,6 +2,10 @@ package succdata
 
 func whenASTFuncLit() {
 	go func() {
+		defer recover()
+	}()
+
+	go func() {
 		defer func() {
 			if r := recover(); r != nil {
 			}
@@ -23,54 +27,4 @@ func whenASTFuncLit() {
 
 		defer rec()
 	}()
-
-	go func() {
-		defer customRecover()
-	}()
-
-}
-
-func whenIdent() {
-	go runGoroutine()
-	go nestedFunc1()
-}
-
-func whenCallMethod() {
-	foo := &Foo{}
-	go foo.run()
-	go func() {
-		defer foo.Recover()
-	}()
-}
-
-func runGoroutine() {
-	defer func() {
-		recover()
-	}()
-}
-
-func nestedFunc1() {
-	// must have recover in parent caller
-	nestedFunc2()
-	defer func() {
-		recover()
-	}()
-}
-
-func nestedFunc2() {}
-
-func customRecover() {
-	recover()
-}
-
-type Foo struct{}
-
-func (a *Foo) run() {
-	defer func() {
-		recover()
-	}()
-}
-
-func (a *Foo) Recover() {
-	recover()
 }


### PR DESCRIPTION
I tried to provide a wider range of checks, but it only increased the complexity of the function. Also, I think the lack of library functions to cover all cases can make the code more complex. So I try to design the inspection step as simple as possible.

1. Function literal is recommended when calling goroutine
2. If the user needs to use a custom recovery then recommend using the -recover option